### PR TITLE
Use tuples for all AST collection fields (instead of lists)

### DIFF
--- a/docs/usage/parser.rst
+++ b/docs/usage/parser.rst
@@ -35,30 +35,30 @@ This will give the same result as manually creating the AST document::
 
     from graphql.language.ast import *
 
-    document = DocumentNode(definitions=[
+    document = DocumentNode(definitions=(
         ObjectTypeDefinitionNode(
             name=NameNode(value='Query'),
-            fields=[
+            fields=(
                 FieldDefinitionNode(
                     name=NameNode(value='me'),
                     type=NamedTypeNode(name=NameNode(value='User')),
-                    arguments=[], directives=[])
-                ], directives=[], interfaces=[]),
+                    arguments=(), directives=()),
+                ), interfaces=(), directives=()),
         ObjectTypeDefinitionNode(
             name=NameNode(value='User'),
-            fields=[
+            fields=(
                 FieldDefinitionNode(
                     name=NameNode(value='id'),
                     type=NamedTypeNode(
                         name=NameNode(value='ID')),
-                    arguments=[], directives=[]),
+                    arguments=(), directives=()),
                 FieldDefinitionNode(
                     name=NameNode(value='name'),
                     type=NamedTypeNode(
                         name=NameNode(value='String')),
-                    arguments=[], directives=[]),
-                ], directives=[], interfaces=[]),
-        ])
+                    arguments=(), directives=()),
+                ), interfaces=(), directives=()),
+        ))
 
 
 When parsing with ``no_location=False`` (the default), the AST nodes will also have a

--- a/src/graphql/utilities/ast_to_dict.py
+++ b/src/graphql/utilities/ast_to_dict.py
@@ -45,14 +45,18 @@ def ast_to_dict(
         elif node in cache:
             return cache[node]
         cache[node] = res = {}
+        # Note: We don't use msgspec.structs.asdict() because loc needs special
+        # handling (converted to {start, end} dict rather than full Location object)
+        # Filter out 'loc' - it's handled separately for the locations option
+        fields = [f for f in node.keys if f != "loc"]
         res.update(
             {
                 key: ast_to_dict(getattr(node, key), locations, cache)
-                for key in ("kind", *node.keys[1:])
+                for key in ("kind", *fields)
             }
         )
         if locations:
-            loc = node.loc
+            loc = getattr(node, "loc", None)
             if loc:
                 res["loc"] = {"start": loc.start, "end": loc.end}
         return res

--- a/src/graphql/utilities/concat_ast.py
+++ b/src/graphql/utilities/concat_ast.py
@@ -17,6 +17,5 @@ def concat_ast(asts: Collection[DocumentNode]) -> DocumentNode:
     the ASTs together into batched AST, useful for validating many GraphQL source files
     which together represent one conceptual application.
     """
-    return DocumentNode(
-        definitions=list(chain.from_iterable(document.definitions for document in asts))
-    )
+    all_definitions = chain.from_iterable(doc.definitions for doc in asts)
+    return DocumentNode(definitions=tuple(all_definitions))

--- a/src/graphql/utilities/separate_operations.py
+++ b/src/graphql/utilities/separate_operations.py
@@ -60,7 +60,7 @@ def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:
         # The list of definition nodes to be included for this operation, sorted
         # to retain the same order as the original document.
         separated_document_asts[operation_name] = DocumentNode(
-            definitions=[
+            definitions=tuple(
                 node
                 for node in document_ast.definitions
                 if node is operation
@@ -68,7 +68,7 @@ def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:
                     isinstance(node, FragmentDefinitionNode)
                     and node.name.value in dependencies
                 )
-            ]
+            )
         )
 
     return separated_document_asts

--- a/tests/language/test_schema_parser.py
+++ b/tests/language/test_schema_parser.py
@@ -78,12 +78,12 @@ def name_node(name: str, loc: Location):
 
 
 def field_node(name: NameNode, type_: TypeNode, loc: Location):
-    return field_node_with_args(name, type_, [], loc)
+    return field_node_with_args(name, type_, (), loc)
 
 
-def field_node_with_args(name: NameNode, type_: TypeNode, args: list, loc: Location):
+def field_node_with_args(name: NameNode, type_: TypeNode, args: tuple, loc: Location):
     return FieldDefinitionNode(
-        name=name, arguments=args, type=type_, directives=[], loc=loc, description=None
+        name=name, arguments=args, type=type_, directives=(), loc=loc, description=None
     )
 
 
@@ -93,7 +93,7 @@ def non_null_type(type_: TypeNode, loc: Location):
 
 def enum_value_node(name: str, loc: Location):
     return EnumValueDefinitionNode(
-        name=name_node(name, loc), directives=[], loc=loc, description=None
+        name=name_node(name, loc), directives=(), loc=loc, description=None
     )
 
 
@@ -104,7 +104,7 @@ def input_value_node(
         name=name,
         type=type_,
         default_value=default_value,
-        directives=[],
+        directives=(),
         loc=loc,
         description=None,
     )
@@ -123,8 +123,8 @@ def list_type_node(type_: TypeNode, loc: Location):
 
 
 def schema_extension_node(
-    directives: list[DirectiveNode],
-    operation_types: list[OperationTypeDefinitionNode],
+    directives: tuple[DirectiveNode, ...],
+    operation_types: tuple[OperationTypeDefinitionNode, ...],
     loc: Location,
 ):
     return SchemaExtensionNode(
@@ -136,7 +136,7 @@ def operation_type_definition(operation: OperationType, type_: TypeNode, loc: Lo
     return OperationTypeDefinitionNode(operation=operation, type=type_, loc=loc)
 
 
-def directive_node(name: NameNode, arguments: list[ArgumentNode], loc: Location):
+def directive_node(name: NameNode, arguments: tuple[ArgumentNode, ...], loc: Location):
     return DirectiveNode(name=name, arguments=arguments, loc=loc)
 
 
@@ -351,14 +351,14 @@ def describe_schema_parser():
         assert doc.loc == (0, 75)
         assert doc.definitions == (
             schema_extension_node(
-                [],
-                [
+                (),
+                (
                     operation_type_definition(
                         OperationType.MUTATION,
                         type_node("Mutation", (53, 61)),
                         (43, 61),
-                    )
-                ],
+                    ),
+                ),
                 (13, 75),
             ),
         )
@@ -370,8 +370,8 @@ def describe_schema_parser():
         assert doc.loc == (0, 24)
         assert doc.definitions == (
             schema_extension_node(
-                [directive_node(name_node("directive", (15, 24)), [], (14, 24))],
-                [],
+                (directive_node(name_node("directive", (15, 24)), (), (14, 24)),),
+                (),
                 (0, 24),
             ),
         )
@@ -571,14 +571,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (38, 44)),
-                [
+                (
                     input_value_node(
                         name_node("flag", (22, 26)),
                         type_node("Boolean", (28, 35)),
                         None,
                         (22, 35),
-                    )
-                ],
+                    ),
+                ),
                 (16, 44),
             ),
         )
@@ -602,14 +602,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (45, 51)),
-                [
+                (
                     input_value_node(
                         name_node("flag", (22, 26)),
                         type_node("Boolean", (28, 35)),
                         boolean_value_node(True, (38, 42)),
                         (22, 42),
-                    )
-                ],
+                    ),
+                ),
                 (16, 51),
             ),
         )
@@ -633,14 +633,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (41, 47)),
-                [
+                (
                     input_value_node(
                         name_node("things", (22, 28)),
                         list_type_node(type_node("String", (31, 37)), (30, 38)),
                         None,
                         (22, 38),
-                    )
-                ],
+                    ),
+                ),
                 (16, 47),
             ),
         )
@@ -664,7 +664,7 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (53, 59)),
-                [
+                (
                     input_value_node(
                         name_node("argOne", (22, 28)),
                         type_node("Boolean", (30, 37)),
@@ -677,7 +677,7 @@ def describe_schema_parser():
                         None,
                         (39, 50),
                     ),
-                ],
+                ),
                 (16, 59),
             ),
         )

--- a/tests/utilities/test_ast_from_value.py
+++ b/tests/utilities/test_ast_from_value.py
@@ -204,13 +204,13 @@ def describe_ast_from_value():
         assert ast_from_value(
             ["FOO", "BAR"], GraphQLList(GraphQLString)
         ) == ConstListValueNode(
-            values=[StringValueNode(value="FOO"), StringValueNode(value="BAR")]
+            values=(StringValueNode(value="FOO"), StringValueNode(value="BAR"))
         )
 
         assert ast_from_value(
             ["HELLO", "GOODBYE"], GraphQLList(my_enum)
         ) == ConstListValueNode(
-            values=[EnumValueNode(value="HELLO"), EnumValueNode(value="GOODBYE")]
+            values=(EnumValueNode(value="HELLO"), EnumValueNode(value="GOODBYE"))
         )
 
         def list_generator():
@@ -220,11 +220,11 @@ def describe_ast_from_value():
 
         assert ast_from_value(list_generator(), GraphQLList(GraphQLInt)) == (
             ConstListValueNode(
-                values=[
+                values=(
                     IntValueNode(value="1"),
                     IntValueNode(value="2"),
                     IntValueNode(value="3"),
-                ]
+                )
             )
         )
 
@@ -239,7 +239,7 @@ def describe_ast_from_value():
         )
 
         assert ast == ConstListValueNode(
-            values=[StringValueNode(value="FOO"), StringValueNode(value="BAR")]
+            values=(StringValueNode(value="FOO"), StringValueNode(value="BAR"))
         )
 
     input_obj = GraphQLInputObjectType(
@@ -251,21 +251,21 @@ def describe_ast_from_value():
         assert ast_from_value(
             {"foo": 3, "bar": "HELLO"}, input_obj
         ) == ConstObjectValueNode(
-            fields=[
+            fields=(
                 ConstObjectFieldNode(
                     name=NameNode(value="foo"), value=FloatValueNode(value="3")
                 ),
                 ConstObjectFieldNode(
                     name=NameNode(value="bar"), value=EnumValueNode(value="HELLO")
                 ),
-            ]
+            )
         )
 
     def converts_input_objects_with_explicit_nulls():
         assert ast_from_value({"foo": None}, input_obj) == ConstObjectValueNode(
-            fields=[
-                ConstObjectFieldNode(name=NameNode(value="foo"), value=NullValueNode())
-            ]
+            fields=(
+                ConstObjectFieldNode(name=NameNode(value="foo"), value=NullValueNode()),
+            )
         )
 
     def does_not_convert_non_object_values_as_input_objects():

--- a/tests/utilities/test_build_ast_schema.py
+++ b/tests/utilities/test_build_ast_schema.py
@@ -133,7 +133,7 @@ def describe_schema_builder():
 
     def match_order_of_default_types_and_directives():
         schema = GraphQLSchema()
-        sdl_schema = build_ast_schema(DocumentNode(definitions=[]))
+        sdl_schema = build_ast_schema(DocumentNode(definitions=()))
 
         assert sdl_schema.directives == schema.directives
         assert sdl_schema.type_map == schema.type_map

--- a/tests/utilities/test_type_info.py
+++ b/tests/utilities/test_type_info.py
@@ -346,7 +346,7 @@ def describe_visit_with_type_info():
                         arguments=node.arguments,
                         directives=node.directives,
                         selection_set=SelectionSetNode(
-                            selections=[FieldNode(name=NameNode(value="__typename"))]
+                            selections=(FieldNode(name=NameNode(value="__typename")),)
                         ),
                     )
 


### PR DESCRIPTION
Prepares AST for immutability by using tuples instead of lists for
collection fields. This aligns with the JavaScript GraphQL library
which uses readonly arrays, and enables future frozen datastructures.

Thank you for contributing to GraphQL-core!

If your pull-request is non-trivial, adds a feature or contains a non-breaking change, then please, first open an issue to discuss the proposed changes and add a link to that issue.

GraphQL-core tries very hard to stay within the scope of being just a Python port of [GraphQL.js](https://github.com/graphql/graphql-js).

Any additional feature or incompatible change will be only accepted in rare cases and requires a compelling reason, because they aggravate maintenance and synchronization with the developments in the upstream project. So please discuss such changes upfront in an issue before sending a PR. Maybe there are other ways to solve the problem.

If possible, also add unit tests, or provide runnable example code as part of the accompanying issue, from which unit tests can be derived.
