### PR TITLE
Make visitor immutable-friendly

### DIFF
--- a/src/graphql/language/visitor.py
+++ b/src/graphql/language/visitor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import copy
 from enum import Enum
 from typing import (
     Any,
@@ -231,9 +230,11 @@ def visit(
                             node[array_key] = edit_value
                     node = tuple(node)
                 else:
-                    node = copy(node)
+                    # Create new node with edited values (immutable-friendly)
+                    values = {k: getattr(node, k) for k in node.keys}
                     for edit_key, edit_value in edits:
-                        setattr(node, edit_key, edit_value)
+                        values[edit_key] = edit_value
+                    node = node.__class__(**values)
             idx = stack.idx
             keys = stack.keys
             edits = stack.edits

--- a/tests/language/test_ast.py
+++ b/tests/language/test_ast.py
@@ -163,6 +163,14 @@ def describe_node_class():
         assert node.beta == 2
         assert not hasattr(node, "gamma")
 
+    def converts_list_to_tuple_on_init():
+        from graphql.language import FieldNode, SelectionSetNode
+
+        field = FieldNode(name=NameNode(value="foo"))
+        node = SelectionSetNode(selections=[field])  # Pass list, not tuple
+        assert isinstance(node.selections, tuple)
+        assert node.selections == (field,)
+
     def has_representation_with_loc():
         node = SampleTestNode(alpha=1, beta=2)
         assert repr(node) == "SampleTestNode"


### PR DESCRIPTION
Modifies the AST visitor to use copy-on-write semantics when applying
edits. Instead of mutating nodes in place, the visitor now creates new
node instances with the edited values. This prepares for frozen AST
nodes while maintaining backwards compatibility.

The visitor accumulates edits and applies them by constructing new
nodes, enabling the transition to immutable data structures.

Thank you for contributing to GraphQL-core!

If your pull-request is non-trivial, adds a feature or contains a non-breaking change, then please, first open an issue to discuss the proposed changes and add a link to that issue.

GraphQL-core tries very hard to stay within the scope of being just a Python port of [GraphQL.js](https://github.com/graphql/graphql-js).

Any additional feature or incompatible change will be only accepted in rare cases and requires a compelling reason, because they aggravate maintenance and synchronization with the developments in the upstream project. So please discuss such changes upfront in an issue before sending a PR. Maybe there are other ways to solve the problem.

If possible, also add unit tests, or provide runnable example code as part of the accompanying issue, from which unit tests can be derived.
