### PR TITLE
Fix tests to use proper AST node construction

### DIFF
--- a/tests/error/test_graphql_error.py
+++ b/tests/error/test_graphql_error.py
@@ -4,7 +4,7 @@ from typing import cast
 
 from graphql.error import GraphQLError
 from graphql.language import (
-    Node,
+    NameNode,
     ObjectTypeDefinitionNode,
     OperationDefinitionNode,
     Source,
@@ -352,7 +352,7 @@ def describe_formatted():
         extensions = {"ext": None}
         error = GraphQLError(
             "test message",
-            Node(),
+            NameNode(value="stub"),
             Source(
                 """
                 query {

--- a/tests/language/test_schema_parser.py
+++ b/tests/language/test_schema_parser.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pickle
 from copy import deepcopy
 from textwrap import dedent
-from typing import Optional, Tuple
 
 import pytest
 
@@ -22,6 +21,7 @@ from graphql.language import (
     InterfaceTypeDefinitionNode,
     InterfaceTypeExtensionNode,
     ListTypeNode,
+    Location,
     NamedTypeNode,
     NameNode,
     NonNullTypeNode,
@@ -32,7 +32,10 @@ from graphql.language import (
     ScalarTypeDefinitionNode,
     SchemaDefinitionNode,
     SchemaExtensionNode,
+    Source,
     StringValueNode,
+    Token,
+    TokenKind,
     TypeNode,
     UnionTypeDefinitionNode,
     ValueNode,
@@ -41,16 +44,19 @@ from graphql.language import (
 
 from ..fixtures import kitchen_sink_sdl  # noqa: F401
 
-try:
-    from typing import TypeAlias
-except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+
+def make_loc(position: tuple[int, int]) -> Location:
+    """Create a Location for testing with the given (start, end) offsets."""
+    source = Source(body="")
+    token = Token(
+        kind=TokenKind.NAME, start=position[0], end=position[1], line=1, column=1
+    )
+    return Location(start_token=token, end_token=token, source=source)
 
 
-Location: TypeAlias = Optional[Tuple[int, int]]
-
-
-def assert_syntax_error(text: str, message: str, location: Location) -> None:
+def assert_syntax_error(
+    text: str, message: str, location: tuple[int, int] | None
+) -> None:
     with pytest.raises(GraphQLSyntaxError) as exc_info:
         parse(text)
     error = exc_info.value
@@ -59,85 +65,104 @@ def assert_syntax_error(text: str, message: str, location: Location) -> None:
     assert error.locations == [location]
 
 
-def assert_definitions(body: str, loc: Location, num=1):
+def assert_definitions(body: str, position: tuple[int, int] | None, num: int = 1):
     doc = parse(body)
     assert isinstance(doc, DocumentNode)
-    assert doc.loc == loc
+    assert doc.loc == position
     definitions = doc.definitions
     assert isinstance(definitions, tuple)
     assert len(definitions) == num
     return definitions[0] if num == 1 else definitions
 
 
-def type_node(name: str, loc: Location):
-    return NamedTypeNode(name=name_node(name, loc), loc=loc)
+def type_node(name: str, position: tuple[int, int]):
+    return NamedTypeNode(name=name_node(name, position), loc=make_loc(position))
 
 
-def name_node(name: str, loc: Location):
-    return NameNode(value=name, loc=loc)
+def name_node(name: str, position: tuple[int, int]):
+    return NameNode(value=name, loc=make_loc(position))
 
 
-def field_node(name: NameNode, type_: TypeNode, loc: Location):
-    return field_node_with_args(name, type_, (), loc)
+def field_node(name: NameNode, type_: TypeNode, position: tuple[int, int]):
+    return field_node_with_args(name, type_, (), position)
 
 
-def field_node_with_args(name: NameNode, type_: TypeNode, args: tuple, loc: Location):
+def field_node_with_args(
+    name: NameNode, type_: TypeNode, args: tuple, position: tuple[int, int]
+):
     return FieldDefinitionNode(
-        name=name, arguments=args, type=type_, directives=(), loc=loc, description=None
+        name=name,
+        arguments=args,
+        type=type_,
+        directives=(),
+        loc=make_loc(position),
+        description=None,
     )
 
 
-def non_null_type(type_: TypeNode, loc: Location):
-    return NonNullTypeNode(type=type_, loc=loc)
+def non_null_type(type_: TypeNode, position: tuple[int, int]):
+    return NonNullTypeNode(type=type_, loc=make_loc(position))
 
 
-def enum_value_node(name: str, loc: Location):
+def enum_value_node(name: str, position: tuple[int, int]):
     return EnumValueDefinitionNode(
-        name=name_node(name, loc), directives=(), loc=loc, description=None
+        name=name_node(name, position),
+        directives=(),
+        loc=make_loc(position),
+        description=None,
     )
 
 
 def input_value_node(
-    name: NameNode, type_: TypeNode, default_value: ValueNode | None, loc: Location
+    name: NameNode,
+    type_: TypeNode,
+    default_value: ValueNode | None,
+    position: tuple[int, int],
 ):
     return InputValueDefinitionNode(
         name=name,
         type=type_,
         default_value=default_value,
         directives=(),
-        loc=loc,
+        loc=make_loc(position),
         description=None,
     )
 
 
-def boolean_value_node(value: bool, loc: Location):
-    return BooleanValueNode(value=value, loc=loc)
+def boolean_value_node(value: bool, position: tuple[int, int]):
+    return BooleanValueNode(value=value, loc=make_loc(position))
 
 
-def string_value_node(value: str, block: bool | None, loc: Location):
-    return StringValueNode(value=value, block=block, loc=loc)
+def string_value_node(value: str, block: bool | None, position: tuple[int, int]):
+    return StringValueNode(value=value, block=block, loc=make_loc(position))
 
 
-def list_type_node(type_: TypeNode, loc: Location):
-    return ListTypeNode(type=type_, loc=loc)
+def list_type_node(type_: TypeNode, position: tuple[int, int]):
+    return ListTypeNode(type=type_, loc=make_loc(position))
 
 
 def schema_extension_node(
     directives: tuple[DirectiveNode, ...],
     operation_types: tuple[OperationTypeDefinitionNode, ...],
-    loc: Location,
+    position: tuple[int, int],
 ):
     return SchemaExtensionNode(
-        directives=directives, operation_types=operation_types, loc=loc
+        directives=directives, operation_types=operation_types, loc=make_loc(position)
     )
 
 
-def operation_type_definition(operation: OperationType, type_: TypeNode, loc: Location):
-    return OperationTypeDefinitionNode(operation=operation, type=type_, loc=loc)
+def operation_type_definition(
+    operation: OperationType, type_: TypeNode, position: tuple[int, int]
+):
+    return OperationTypeDefinitionNode(
+        operation=operation, type=type_, loc=make_loc(position)
+    )
 
 
-def directive_node(name: NameNode, arguments: tuple[ArgumentNode, ...], loc: Location):
-    return DirectiveNode(name=name, arguments=arguments, loc=loc)
+def directive_node(
+    name: NameNode, arguments: tuple[ArgumentNode, ...], position: tuple[int, int]
+):
+    return DirectiveNode(name=name, arguments=arguments, loc=make_loc(position))
 
 
 def describe_schema_parser():

--- a/tests/type/test_definition.py
+++ b/tests/type/test_definition.py
@@ -25,11 +25,15 @@ from graphql.language import (
     InputValueDefinitionNode,
     InterfaceTypeDefinitionNode,
     InterfaceTypeExtensionNode,
+    NamedTypeNode,
+    NameNode,
     ObjectTypeDefinitionNode,
     ObjectTypeExtensionNode,
     OperationDefinitionNode,
+    OperationType,
     ScalarTypeDefinitionNode,
     ScalarTypeExtensionNode,
+    SelectionSetNode,
     StringValueNode,
     UnionTypeDefinitionNode,
     UnionTypeExtensionNode,
@@ -62,6 +66,16 @@ try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
     from typing_extensions import TypeGuard
+
+
+# Helper functions to create stub AST nodes with required fields
+def _stub_name(name: str = "Stub") -> NameNode:
+    return NameNode(value=name)
+
+
+def _stub_type() -> NamedTypeNode:
+    return NamedTypeNode(name=_stub_name("StubType"))
+
 
 ScalarType = GraphQLScalarType("Scalar")
 ObjectType = GraphQLObjectType("Object", {})
@@ -165,8 +179,8 @@ def describe_type_system_scalars():
         )
 
     def accepts_a_scalar_type_with_ast_node_and_extension_ast_nodes():
-        ast_node = ScalarTypeDefinitionNode()
-        extension_ast_nodes = [ScalarTypeExtensionNode()]
+        ast_node = ScalarTypeDefinitionNode(name=_stub_name())
+        extension_ast_nodes = [ScalarTypeExtensionNode(name=_stub_name())]
         scalar = GraphQLScalarType(
             "SomeScalar", ast_node=ast_node, extension_ast_nodes=extension_ast_nodes
         )
@@ -435,8 +449,8 @@ def describe_type_system_objects():
         assert obj_type.fields
 
     def accepts_an_object_type_with_ast_node_and_extension_ast_nodes():
-        ast_node = ObjectTypeDefinitionNode()
-        extension_ast_nodes = [ObjectTypeExtensionNode()]
+        ast_node = ObjectTypeDefinitionNode(name=_stub_name())
+        extension_ast_nodes = [ObjectTypeExtensionNode(name=_stub_name())]
         object_type = GraphQLObjectType(
             "SomeObject",
             {"f": GraphQLField(ScalarType)},
@@ -601,8 +615,8 @@ def describe_type_system_interfaces():
         assert calls == 1
 
     def accepts_an_interface_type_with_ast_node_and_extension_ast_nodes():
-        ast_node = InterfaceTypeDefinitionNode()
-        extension_ast_nodes = [InterfaceTypeExtensionNode()]
+        ast_node = InterfaceTypeDefinitionNode(name=_stub_name())
+        extension_ast_nodes = [InterfaceTypeExtensionNode(name=_stub_name())]
         interface_type = GraphQLInterfaceType(
             "SomeInterface",
             {"f": GraphQLField(ScalarType)},
@@ -667,8 +681,8 @@ def describe_type_system_unions():
         assert union_type.types == ()
 
     def accepts_a_union_type_with_ast_node_and_extension_ast_nodes():
-        ast_node = UnionTypeDefinitionNode()
-        extension_ast_nodes = [UnionTypeExtensionNode()]
+        ast_node = UnionTypeDefinitionNode(name=_stub_name())
+        extension_ast_nodes = [UnionTypeExtensionNode(name=_stub_name())]
         union_type = GraphQLUnionType(
             "SomeUnion",
             [ObjectType],
@@ -894,8 +908,8 @@ def describe_type_system_enums():
         )
 
     def accepts_an_enum_type_with_ast_node_and_extension_ast_nodes():
-        ast_node = EnumTypeDefinitionNode()
-        extension_ast_nodes = [EnumTypeExtensionNode()]
+        ast_node = EnumTypeDefinitionNode(name=_stub_name())
+        extension_ast_nodes = [EnumTypeExtensionNode(name=_stub_name())]
         enum_type = GraphQLEnumType(
             "SomeEnum",
             {},
@@ -1010,8 +1024,8 @@ def describe_type_system_input_objects():
         assert input_obj_type.to_kwargs()["out_type"] is None
 
     def accepts_an_input_object_type_with_ast_node_and_extension_ast_nodes():
-        ast_node = InputObjectTypeDefinitionNode()
-        extension_ast_nodes = [InputObjectTypeExtensionNode()]
+        ast_node = InputObjectTypeDefinitionNode(name=_stub_name())
+        extension_ast_nodes = [InputObjectTypeExtensionNode(name=_stub_name())]
         input_obj_type = GraphQLInputObjectType(
             "SomeInputObject",
             {},
@@ -1126,7 +1140,7 @@ def describe_type_system_arguments():
         assert argument.to_kwargs()["out_name"] is None
 
     def accepts_an_argument_with_an_ast_node():
-        ast_node = InputValueDefinitionNode()
+        ast_node = InputValueDefinitionNode(name=_stub_name(), type=_stub_type())
         argument = GraphQLArgument(GraphQLString, ast_node=ast_node)
         assert argument.ast_node is ast_node
         assert argument.to_kwargs()["ast_node"] is ast_node
@@ -1157,7 +1171,7 @@ def describe_type_system_input_fields():
         assert input_field.to_kwargs()["out_name"] is None
 
     def accepts_an_input_field_with_an_ast_node():
-        ast_node = InputValueDefinitionNode()
+        ast_node = InputValueDefinitionNode(name=_stub_name(), type=_stub_type())
         input_field = GraphQLArgument(GraphQLString, ast_node=ast_node)
         assert input_field.ast_node is ast_node
         assert input_field.to_kwargs()["ast_node"] is ast_node
@@ -1299,7 +1313,9 @@ def describe_resolve_info():
         "schema": GraphQLSchema(),
         "fragments": {},
         "root_value": None,
-        "operation": OperationDefinitionNode(),
+        "operation": OperationDefinitionNode(
+            operation=OperationType.QUERY, selection_set=SelectionSetNode()
+        ),
         "variable_values": {},
         "is_awaitable": is_awaitable,
     }

--- a/tests/type/test_directives.py
+++ b/tests/type/test_directives.py
@@ -1,14 +1,18 @@
 import pytest
 
 from graphql.error import GraphQLError
-from graphql.language import DirectiveDefinitionNode, DirectiveLocation
+from graphql.language import DirectiveDefinitionNode, DirectiveLocation, NameNode
 from graphql.type import GraphQLArgument, GraphQLDirective, GraphQLInt, GraphQLString
 
 
 def describe_type_system_directive():
     def can_create_instance():
         arg = GraphQLArgument(GraphQLString, description="arg description")
-        node = DirectiveDefinitionNode()
+        node = DirectiveDefinitionNode(
+            name=NameNode(value="test"),
+            repeatable=False,
+            locations=(),
+        )
         locations = [DirectiveLocation.SCHEMA, DirectiveLocation.OBJECT]
         directive = GraphQLDirective(
             name="test",

--- a/tests/type/test_schema.py
+++ b/tests/type/test_schema.py
@@ -425,7 +425,7 @@ def describe_type_system_schema():
 
     def describe_ast_nodes():
         def accepts_a_scalar_type_with_ast_node_and_extension_ast_nodes():
-            ast_node = SchemaDefinitionNode()
+            ast_node = SchemaDefinitionNode(operation_types=())
             extension_ast_nodes = [SchemaExtensionNode()]
             schema = GraphQLSchema(
                 GraphQLObjectType("Query", {}),


### PR DESCRIPTION
Tests were using incomplete node construction that relied on
default None values. This change makes tests more representative
in preparation for non-nullable required fields.

Thank you for contributing to GraphQL-core!

If your pull-request is non-trivial, adds a feature or contains a non-breaking change, then please, first open an issue to discuss the proposed changes and add a link to that issue.

GraphQL-core tries very hard to stay within the scope of being just a Python port of [GraphQL.js](https://github.com/graphql/graphql-js).

Any additional feature or incompatible change will be only accepted in rare cases and requires a compelling reason, because they aggravate maintenance and synchronization with the developments in the upstream project. So please discuss such changes upfront in an issue before sending a PR. Maybe there are other ways to solve the problem.

If possible, also add unit tests, or provide runnable example code as part of the accompanying issue, from which unit tests can be derived.
