### PR TITLE
Update minimum Python version to 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.9', 'pypy3.10', 'pypy3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.10', 'pypy3.11']
 
     steps:
       - name: Checkout project
@@ -37,44 +37,3 @@ jobs:
       - name: Run unit tests with tox
         id: test
         run: tox
-
-  tests-old:
-    name: 🧪 Tests (older Python versions)
-    runs-on: ubuntu-22.04
-
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8']
-
-    steps:
-      - name: Checkout project
-        id: checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Python 3.14 (tox runner)
-        id: setup-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Install uv
-        id: setup-uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Install tox and plugins
-        id: install-tox
-        run: |
-          uv pip install --system tox tox-uv tox-gh-actions
-
-      - name: Set up target Python ${{ matrix.python-version }}
-        id: setup-target-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run unit tests with tox for target
-        id: test
-        shell: bash
-        run: |
-          ENV="py${{ matrix.python-version }}"; ENV=${ENV/./}
-          python3.14 -m tox -e "$ENV"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "graphql-core"
 version = "3.3.0a11"
 description = "GraphQL-core is a Python port of GraphQL.js, the JavaScript reference implementation for GraphQL."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [ { name = "Christoph Zwerschke", email = "cito@online.de" } ]
@@ -13,19 +13,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = [
-    "typing-extensions>=4.12.2,<5; python_version >= '3.8' and python_version < '3.10'",
-    "typing-extensions>=4.7.1,<5; python_version < '3.8'",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/graphql-python/graphql-core"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9,10,11,12,13,14}, pypy3{9,10,11}, ruff, mypy, docs
+envlist = py3{10,11,12,13,14}, pypy3{10,11}, ruff, mypy, docs
 isolated_build = true
 requires =
     tox>=4.8
@@ -9,16 +9,12 @@ installer = uv
 [gh-actions]
 python =
     3: py314
-    3.7: py37
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
     3.14: py314
     pypy3: pypy311
-    pypy3.9: pypy39
     pypy3.10: pypy310
     pypy3.11: pypy311
 
@@ -54,5 +50,5 @@ pass_env =
 commands =
     # to also run the time-consuming tests: tox -e py314 -- --run-slow
     # to run the benchmarks: tox -e py314 -- -k benchmarks --benchmark-enable
-    py3{7,8,9,10,11,12,13},pypy3{9,10,11}: python -m pytest tests {posargs}
+    py3{10,11,12,13},pypy3{10,11}: python -m pytest tests {posargs}
     py314: python -m pytest tests {posargs: --cov-report=term-missing --cov=graphql --cov=tests --cov-fail-under=100}


### PR DESCRIPTION
Python 3.9 reaches end-of-life October 2025. Python 3.10 adoption is
now mainstream - major frameworks (strawberry, Django 5.0, FastAPI) require it.

This enables modern Python features:
- Dataclasses with `kw_only`
- Union types with `|` syntax (PEP 604)
- isinstance() with union types directly
- match statements for pattern matching

Thank you for contributing to GraphQL-core!

If your pull-request is non-trivial, adds a feature or contains a non-breaking change, then please, first open an issue to discuss the proposed changes and add a link to that issue.

GraphQL-core tries very hard to stay within the scope of being just a Python port of [GraphQL.js](https://github.com/graphql/graphql-js).

Any additional feature or incompatible change will be only accepted in rare cases and requires a compelling reason, because they aggravate maintenance and synchronization with the developments in the upstream project. So please discuss such changes upfront in an issue before sending a PR. Maybe there are other ways to solve the problem.

If possible, also add unit tests, or provide runnable example code as part of the accompanying issue, from which unit tests can be derived.
